### PR TITLE
feat(emojiLog): Add Emoji Log commit parser

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -61,6 +61,8 @@ component {
             .to( "#moduleMapping#.models.plugins.JGitCommitsRetriever" );
         binder.map( "ConventionalChangelogParser@commandbox-semantic-release" )
             .to( "#moduleMapping#.models.plugins.ConventionalChangelogParser" );
+        binder.map( "EmojiLogCommitParser@commandbox-semantic-release" )
+            .to( "#moduleMapping#.models.plugins.EmojiLogCommitParser" );
         binder.map( "DefaultCommitFilterer@commandbox-semantic-release" )
             .to( "#moduleMapping#.models.plugins.DefaultCommitFilterer" );
         binder.map( "DefaultCommitAnalyzer@commandbox-semantic-release" )

--- a/models/plugins/EmojiLogCommitParser.cfc
+++ b/models/plugins/EmojiLogCommitParser.cfc
@@ -39,7 +39,7 @@ component implements="interfaces.CommitParser" {
         var parts = arraySlice( replace( commit.getFullMessage(), chr( 13 ), "", "all" ).split("\n{2,}"), 1 );
 
         /**
-         * @see https://regex101.com/r/JkO3F3/1/
+         * @see https://regex101.com/r/JkO3F3/2/
          */
         emojiLogRegex = "^([📦|👌|🐛|📖|🚀|🤖|‼️|⚠️]+\s\w+)(\([^)]+\))?\:\s(.+)$";
         topParts = reFindNoCase( emojiLogRegex, parts[ 1 ], 1, true );
@@ -47,9 +47,8 @@ component implements="interfaces.CommitParser" {
         ccCommit[ "type" ] = topParts.pos.len() >= 2 ?
             mid( parts[ 1 ], topParts.pos[ 2 ], topParts.len[ 2 ] ) :
             "📝 OTHER";
-        if ( ccCommit[ "type" ] == "‼️ BREAKING CHANGE" ){
-            ccCommit[ "type" ] = "⚠️ BREAKING CHANGE";
-        }
+        // Switch out the BREAKING emoji with one that renders
+        ccCommit[ "type" ] = replace( ccCommit[ "type"], "‼️ BREAKING","⚠️ BREAKING" );
         ccCommit[ "scope" ] = topParts.pos.len() >= 3 && topParts.pos[3] > 0 ?
             reReplace(mid( parts[ 1 ], topParts.pos[ 3 ], topParts.len[ 3 ] ), "[()]","", "ALL") :
             "*";
@@ -58,7 +57,7 @@ component implements="interfaces.CommitParser" {
             "";
         ccCommit[ "body" ] = topParts.pos.len() == 1 ? parts[ 1 ] : parts[ 2 ] ?: "";
         ccCommit[ "footer" ] = parts[ 3 ] ?: "";
-        ccCommit[ "isBreakingChange" ] = find( "BREAKING CHANGE:", commit.getFullMessage() ) > 0;
+        ccCommit[ "isBreakingChange" ] = find( "BREAKING:", commit.getFullMessage() ) > 0;
         ccCommit[ "hash" ] = commit.getId().getName();
         ccCommit[ "shortHash" ] = objectReader.abbreviate( commit.getId() ).name();
 

--- a/models/plugins/EmojiLogCommitParser.cfc
+++ b/models/plugins/EmojiLogCommitParser.cfc
@@ -1,0 +1,88 @@
+component implements="interfaces.CommitParser" {
+
+    property name="fileSystemUtil" inject="FileSystem";
+    property name="print"          inject="PrintBuffer";
+
+    /**
+     * Set up jGit for the current repository to enable short hashes.
+     */
+    function onDIComplete() {
+        var builder = createObject( "java", "org.eclipse.jgit.storage.file.FileRepositoryBuilder" ).init();
+        var gitDir = createObject( "java", "java.io.File" ).init( fileSystemUtil.resolvePath( "" ) & ".git" );
+
+        var repository = builder
+            .setGitDir( gitDir )
+            .setMustExist( true )
+            .readEnvironment() // scan environment GIT_* variables
+            .findGitDir() // scan up the file system tree
+            .build();
+
+        variables.objectReader = repository.newObjectReader();
+    }
+
+    /**
+    * Converts the commit from a jGit version to a different format used by
+    * the rest of the semantic release process.
+    *
+    * @commit  The commit to convert.
+    * @dryRun  Flag to indicate a dry run of the release.
+    * @verbose Flag to indicate printing out extra information.
+    *
+    * @return  A converted commit.
+    */
+    public any function run(
+        required any commit,
+        boolean dryRun = false,
+        boolean verbose = false
+    ) {
+        var ccCommit = {};
+        var parts = arraySlice( replace( commit.getFullMessage(), chr( 13 ), "", "all" ).split("\n{2,}"), 1 );
+
+        /**
+         * @see https://regex101.com/r/JkO3F3/1/
+         */
+        emojiLogRegex = "^([📦|👌|🐛|📖|🚀|🤖|‼️|⚠️]+\s\w+)(\([^)]+\))?\:\s(.+)$";
+        topParts = reFindNoCase( emojiLogRegex, parts[ 1 ], 1, true );
+
+        ccCommit[ "type" ] = topParts.pos.len() >= 2 ?
+            mid( parts[ 1 ], topParts.pos[ 2 ], topParts.len[ 2 ] ) :
+            "📝 OTHER";
+        if ( ccCommit[ "type" ] == "‼️ BREAKING CHANGE" ){
+            ccCommit[ "type" ] = "⚠️ BREAKING CHANGE";
+        }
+        ccCommit[ "scope" ] = topParts.pos.len() >= 3 && topParts.pos[3] > 0 ?
+            reReplace(mid( parts[ 1 ], topParts.pos[ 3 ], topParts.len[ 3 ] ), "[()]","", "ALL") :
+            "*";
+        ccCommit[ "subject" ] = topParts.pos.len() >= 4 ?
+            mid( parts[ 1 ], topParts.pos[ 4 ], topParts.len[ 4 ] ) :
+            "";
+        ccCommit[ "body" ] = topParts.pos.len() == 1 ? parts[ 1 ] : parts[ 2 ] ?: "";
+        ccCommit[ "footer" ] = parts[ 3 ] ?: "";
+        ccCommit[ "isBreakingChange" ] = find( "BREAKING CHANGE:", commit.getFullMessage() ) > 0;
+        ccCommit[ "hash" ] = commit.getId().getName();
+        ccCommit[ "shortHash" ] = objectReader.abbreviate( commit.getId() ).name();
+
+        if ( verbose ) {
+            prettyPrintCommit( ccCommit );
+        }
+
+        return ccCommit;
+    }
+
+    /**
+     * Print a parsed commit in a nice format to the console.
+     *
+     * @commit The commit to print
+     */
+    private function prettyPrintCommit( commit ) {
+        print.line();
+        print.indented().indented().indentedMagenta( "   Hash: " ).line( commit.shortHash );
+        print.indented().indented().indentedMagenta( "   Type: " ).line( commit.type );
+        print.indented().indented().indentedMagenta( "  Scope: " ).line( commit.scope );
+        print.indented().indented().indentedMagenta( "Subject: " ).line( commit.subject );
+        print.indented().indented().indentedMagenta( "   Body: " ).line( commit.body );
+        print.indented().indented().indentedMagenta( " Footer: " ).line( commit.footer );
+        print.line().toConsole();
+    }
+
+}


### PR DESCRIPTION
Enables commit parsing for the [Emoji Log commit standard](https://marketplace.visualstudio.com/items?itemName=ahmadawais.emoji-log-vscode).

See https://regex101.com/r/JkO3F3/2/

Resolves #8.

NOTE: This feature would be best served with an additional `EmojiLogMarkdownNotesGenerator.cfc` plugin. Why? Because 
1. the Emoji Log standard doesn't really allow for a "scope"
2. the notes look silly without them. (everything is prefixed with a `*` scope.)
3. The "Breaking" commits are currently hardcoded to a `BREAKING` header, and there's no way to change it without modifying the `GithubMarkdownNotesGenerator.cfc`.

![Screenshot from 2021-08-05 15-31-16](https://user-images.githubusercontent.com/8106227/128409850-28e0a883-448c-454a-80d7-0aa1c10854e6.png)
