### PR TITLE
feat: Add type detection of Emoji Log commits

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -67,6 +67,8 @@ component {
             .to( "#moduleMapping#.models.plugins.DefaultCommitFilterer" );
         binder.map( "DefaultCommitAnalyzer@commandbox-semantic-release" )
             .to( "#moduleMapping#.models.plugins.DefaultCommitAnalyzer" );
+        binder.map( "EmojiLogCommitAnalyzer@commandbox-semantic-release" )
+            .to( "#moduleMapping#.models.plugins.EmojiLogCommitAnalyzer" );
         binder.map( "NullReleaseVerifier@commandbox-semantic-release" )
             .to( "#moduleMapping#.models.plugins.NullReleaseVerifier" );
         binder.map( "GitHubMarkdownNotesGenerator@commandbox-semantic-release" )

--- a/models/plugins/EmojiLogCommitAnalyzer.cfc
+++ b/models/plugins/EmojiLogCommitAnalyzer.cfc
@@ -1,0 +1,42 @@
+component implements="interfaces.CommitAnalyzer" {
+
+    /**
+    * Returns the release type given the array of commits.
+    *
+    * @commits An array of commits to analyze for the next change.
+    * @dryRun  Flag to indicate a dry run of the release.
+    * @verbose Flag to indicate printing out extra information.
+    *
+    * @return  The next release type: major, minor, or patch.
+    */
+    public string function run(
+        required array commits,
+        boolean dryRun = false,
+        boolean verbose = false
+    ) {
+        return commits.reduce( function( maxType, commit ) {
+            if ( maxType == "major" ) {
+                return "major";
+            }
+
+            if ( listFind( "🚀 RELEASE", commit.type ) ) {
+                return "major";
+            }
+
+            if ( commit.isBreakingChange ) {
+                return "major";
+            }
+
+            if ( maxType == "minor" ) {
+                return "minor";
+            }
+
+            if ( listFind( "📦 NEW,👌 IMPROVE,🤖 TEST,📖 DOC", commit.type ) ) {
+                return "minor";
+            }
+
+            return "patch";
+        }, "patch" );
+    }
+
+}


### PR DESCRIPTION
Corrects issues with Emoji Log commits not being correctly detected as major/minor/patch commit types.