### PR TITLE
WIP: Commandline options prerelease

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 
 ### Thanks and Prior Art
 
-* [semantic-release](https://github.com/semantic-release/semantic-release)
-* [How to Write an Open Source Javascript Library](https://egghead.io/courses/how-to-write-an-open-source-javascript-library) on [Egghead.io](https://egghead.io) by [Kent C. Dodds](https://kentcdodds.com).
+- [semantic-release](https://github.com/semantic-release/semantic-release)
+- [How to Write an Open Source Javascript Library](https://egghead.io/courses/how-to-write-an-open-source-javascript-library) on [Egghead.io](https://egghead.io) by [Kent C. Dodds](https://kentcdodds.com).
 
 ### Why? / Benefits
 
-* Stop thinking about what the next version should be.
-* Releases happen on Continuous Integration (CI) servers. You don't even need
+- Stop thinking about what the next version should be.
+- Releases happen on Continuous Integration (CI) servers. You don't even need
   to be at a computer. Releases from your smartphone just by merging a pull request.
-* Automatic changelog generation.
+- Automatic changelog generation.
 
 The package was written due to a desire to be able to release a new version of a library
 after merging a pull request without having to open my computer and run some scripts
@@ -39,16 +39,16 @@ These setup steps only need to happen once per repository set up with CommandBox
 > your `.travis.yml` file, add your encrypted environment variables to Travis CI,
 > and start committing with the conventional changelog format!
 
-* Host your repository on GitHub.
-* Have a [ForgeBox](https://www.forgebox.io) account
-* [Activate the repository](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI) on Travis CI.
-* Configure your `box.json`.
-* Add a `.travis.yml` file.
-* Adding encrypted environment variables to Travis CI
-    * `GH_TOKEN`
-    * `TRAVIS_TOKEN`
-    * `FORGEBOX_TOKEN`
-* Follow the [conventional changelog](https://github.com/conventional-changelog/conventional-changelog) commit message format.
+- Host your repository on GitHub.
+- Have a [ForgeBox](https://www.forgebox.io) account
+- [Activate the repository](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI) on Travis CI.
+- Configure your `box.json`.
+- Add a `.travis.yml` file.
+- Adding encrypted environment variables to Travis CI
+  - `GH_TOKEN`
+  - `TRAVIS_TOKEN`
+  - `FORGEBOX_TOKEN`
+- Follow the [conventional changelog](https://github.com/conventional-changelog/conventional-changelog) commit message format.
 
 ##### Host your repository on GitHub.
 
@@ -113,22 +113,34 @@ notifications:
   email: false
 ```
 
+Also supports targetBranch, preReleaseIDs and BuildIDs from the CommandLine
+
+```
+box semantic-release targetBranch=development prereleaseid=snapshot buildid=3456
+```
+
+This will create a version in the format: `v1.0.5-snapshot.3456`
+
+Or as Environment Variables for CI Pipeline integration
+_ `BUILD_VERSION_PRERELEASEID`
+_ `BUILD_VERSION_BUILDID`
+
 ##### Adding encrypted enviornment variables to Travis CI
 
 You will need the following environment variables available to your build on Travis CI:
 
-* `GH_TOKEN`
+- `GH_TOKEN`
 
 A GitHub personal access token with `repo` scopes. This is used to push changes
 made on your CI server (like version updates and changelogs) back to GitHub.
 
-* `TRAVIS_TOKEN`
+- `TRAVIS_TOKEN`
 
 A Travis CI personal access token. This is used to check the status of other jobs
 in the build to avoid cutting a new release if only one job of a build fails. It
 also prevents more than one job in a single build releasing a new version.
 
-* `FORGEBOX_TOKEN`
+- `FORGEBOX_TOKEN`
 
 A ForgeBox API token. This is used to publish a new release in ForgeBox. If the
 package in question is a private package, the token will be needed to retrieve
@@ -216,11 +228,11 @@ This will automatically generate a `CHANGELOG.md` file and tag the release on Gi
 
 ### feat
 
-* **Collection:** Add push, unshift, and splice methods ([e7c3efb](https://github.com/elpete/cfcollection/commit/e7c3efb50e0fe249cb531a9c3327724ab896b87d))
+- **Collection:** Add push, unshift, and splice methods ([e7c3efb](https://github.com/elpete/cfcollection/commit/e7c3efb50e0fe249cb531a9c3327724ab896b87d))
 
 ### fix
 
-* **box.json:** Revert version to the actual version ([41f1185](https://github.com/elpete/cfcollection/commit/41f1185ddd439d06b361d5874962ff77c2b6458e))
+- **box.json:** Revert version to the actual version ([41f1185](https://github.com/elpete/cfcollection/commit/41f1185ddd439d06b361d5874962ff77c2b6458e))
 ```
 
 #### `dryRun`

--- a/models/plugins/GitHubActionsConditionsVerifier.cfc
+++ b/models/plugins/GitHubActionsConditionsVerifier.cfc
@@ -11,10 +11,11 @@ component implements="interfaces.ConditionsVerifier" {
     *
     * @dryRun  Flag to indicate a dry run of the release.
     * @verbose Flag to indicate printing out extra information.
+    * @targetBranch     The branch that builds are triggered against.
     *
     * @returns True if the release should run.
     */
-    public boolean function run( boolean dryRun = false, boolean verbose = false ) {
+    public boolean function run( boolean dryRun = false, boolean verbose = false, string targetBranch = variables.targetBranch ) {
         // false if build skip commit message
         if ( findNoCase( systemSettings.getSystemSetting( "BUILD_SKIP_COMMIT_MESSAGE", "[skip release]" ), systemSettings.getSystemSetting( "GA_COMMIT_MESSAGE", "" ) ) > 0 ) {
             print.yellowLine( "Commit requests the build to be skipped — aborting release." ).toConsole();

--- a/models/plugins/GitHubArtifactsCommitter.cfc
+++ b/models/plugins/GitHubArtifactsCommitter.cfc
@@ -30,11 +30,13 @@ component implements="interfaces.ArtifactsCommitter" {
      * @nextVersion The next version to be published.
      * @dryRun  Flag to indicate a dry run of the release.
      * @verbose Flag to indicate printing out extra information.
+     * @targetBranch     The branch that builds are triggered against.
      */
     public void function run(
         required string nextVersion,
         boolean dryRun = false,
-        boolean verbose = false
+        boolean verbose = false,
+        string targetBranch = variables.targetBranch
     ) {
         if ( dryRun ) {
             return;

--- a/models/plugins/GitHubReleasePublicizer.cfc
+++ b/models/plugins/GitHubReleasePublicizer.cfc
@@ -13,13 +13,15 @@ component implements="interfaces.ReleasePublicizer" {
      * @repositoryUrl The url of the remote repository.
      * @dryRun        Flag to indicate a dry run of the release.
      * @verbose       Flag to indicate printing out extra information.
+     * @targetBranch     The branch that builds are triggered against.
      */
     public void function run(
         required string notes,
         required string nextVersion,
         required string repositoryUrl,
         boolean dryRun = false,
-        boolean verbose = false
+        boolean verbose = false,
+        string targetBranch = variables.targetBranch
     ) {
         if ( dryRun ) {
             return;

--- a/models/plugins/GitLabArtifactsCommitter.cfc
+++ b/models/plugins/GitLabArtifactsCommitter.cfc
@@ -29,11 +29,13 @@ component implements="interfaces.ArtifactsCommitter" {
      * @nextVersion The next version to be published.
      * @dryRun  Flag to indicate a dry run of the release.
      * @verbose Flag to indicate printing out extra information.
+     * @targetBranch     The branch that builds are triggered against.
      */
     public void function run(
         required string nextVersion,
         boolean dryRun = false,
-        boolean verbose = false
+        boolean verbose = false,
+        string targetBranch = variables.targetBranch
     ) {
         if ( dryRun ) {
             return;

--- a/models/plugins/GitLabConditionsVerifier.cfc
+++ b/models/plugins/GitLabConditionsVerifier.cfc
@@ -11,10 +11,11 @@ component implements="interfaces.ConditionsVerifier" {
     *
     * @dryRun  Flag to indicate a dry run of the release.
     * @verbose Flag to indicate printing out extra information.
+    * @targetBranch     The branch that builds are triggered against.
     *
     * @returns True if the release should run.
     */
-    public boolean function run( boolean dryRun = false, boolean verbose = false ) {
+    public boolean function run( boolean dryRun = false, boolean verbose = false, string targetBranch = variables.targetBranch ) {
         if ( dryRun ) {
             return true;
         }

--- a/models/plugins/GitLabReleasePublicizer.cfc
+++ b/models/plugins/GitLabReleasePublicizer.cfc
@@ -12,13 +12,15 @@ component implements="interfaces.ReleasePublicizer" {
      * @repositoryUrl The url of the remote repository.
      * @dryRun        Flag to indicate a dry run of the release.
      * @verbose       Flag to indicate printing out extra information.
+     * @targetBranch     The branch that builds are triggered against.
      */
     public void function run(
         required string notes,
         required string nextVersion,
         required string repositoryUrl,
         boolean dryRun = false,
-        boolean verbose = false
+        boolean verbose = false,
+        string targetBranch = variables.targetBranch
     ) {
         if ( dryRun ) {
             return;

--- a/models/plugins/NullArtifactsCommitter.cfc
+++ b/models/plugins/NullArtifactsCommitter.cfc
@@ -6,11 +6,13 @@ component implements="interfaces.ArtifactsCommitter" {
      * @nextVersion The next version to be published.
      * @dryRun  Flag to indicate a dry run of the release.
      * @verbose Flag to indicate printing out extra information.
+     * @targetBranch     The branch that builds are triggered against.
      */
     public void function run(
         required string nextVersion,
         boolean dryRun = false,
-        boolean verbose = false
+        boolean verbose = false, 
+        string targetBranch = variables.targetBranch
     ) {
         return;
     }

--- a/models/plugins/NullConditionsVerifier.cfc
+++ b/models/plugins/NullConditionsVerifier.cfc
@@ -5,10 +5,11 @@ component implements="interfaces.ConditionsVerifier" {
     *
     * @dryRun  Flag to indicate a dry run of the release.
     * @verbose Flag to indicate printing out extra information.
+    * @targetBranch     The branch that builds are triggered against.
     *
     * @returns True if the release should run.
     */
-    public boolean function run( boolean dryRun = false, boolean verbose = false ) {
+    public boolean function run( boolean dryRun = false, boolean verbose = false, string targetBranch = variables.targetBranch ) {
         return true;
     }
 

--- a/models/plugins/TravisConditionsVerifier.cfc
+++ b/models/plugins/TravisConditionsVerifier.cfc
@@ -12,10 +12,11 @@ component implements="interfaces.ConditionsVerifier" {
     *
     * @dryRun  Flag to indicate a dry run of the release.
     * @verbose Flag to indicate printing out extra information.
+    * @targetBranch     The branch that builds are triggered against.
     *
     * @returns True if the release should run.
     */
-    public boolean function run( boolean dryRun = false, boolean verbose = false ) {
+    public boolean function run( boolean dryRun = false, boolean verbose = false, string targetBranch = variables.targetBranch ) {
         // false if build skip commit message
         if ( findNoCase( systemSettings.getSystemSetting( "BUILD_SKIP_COMMIT_MESSAGE", "[skip release]" ), systemSettings.getSystemSetting( "TRAVIS_COMMIT_MESSAGE", "" ) ) > 0 ) {
             print.yellowLine( "Commit requests the build to be skipped — aborting release." ).toConsole();

--- a/models/plugins/interfaces/ArtifactsCommitter.cfc
+++ b/models/plugins/interfaces/ArtifactsCommitter.cfc
@@ -6,11 +6,13 @@ interface {
      * @nextVersion The next version to be published.
      * @dryRun      Flag to indicate a dry run of the release.
      * @verbose     Flag to indicate printing out extra information.
+     * @targetBranch     The branch that builds are triggered against.
      */
     public void function run(
         required string nextVersion,
         boolean dryRun,
-        boolean verbose
+        boolean verbose,
+        string targetBranch = variables.targetBranch
     );
 
 }

--- a/models/plugins/interfaces/ConditionsVerifier.cfc
+++ b/models/plugins/interfaces/ConditionsVerifier.cfc
@@ -5,9 +5,10 @@ interface {
     *
     * @dryRun  Flag to indicate a dry run of the release.
     * @verbose Flag to indicate printing out extra information.
+    * @targetBranch     The branch that builds are triggered against.
     *
     * @returns True if the release should run.
     */
-    public boolean function run( boolean dryRun, boolean verbose );
+    public boolean function run( boolean dryRun, boolean verbose, string targetBranch = variables.targetBranch );
 
 }

--- a/models/plugins/interfaces/ReleasePublicizer.cfc
+++ b/models/plugins/interfaces/ReleasePublicizer.cfc
@@ -8,13 +8,15 @@ interface {
      * @repositoryUrl The url of the remote repository.
      * @dryRun        Flag to indicate a dry run of the release.
      * @verbose       Flag to indicate printing out extra information.
+     * @targetBranch     The branch that builds are triggered against.
      */
     public void function run(
         required string notes,
         required string nextVersion,
         required string repositoryUrl,
         boolean dryRun,
-        boolean verbose
+        boolean verbose,
+        string targetBranch = variables.targetBranch
     );
 
 }


### PR DESCRIPTION
A working version of commandline options and env variables for: 

- preReleaseID
- buildID

Also supports passing the targetBranch into the command line for one off commands, without setting your targetBranch in your settings for all other apps etc.